### PR TITLE
Updated ARP broadcast tests to check for packet-ins

### DIFF
--- a/tests/ptf/Makefile
+++ b/tests/ptf/Makefile
@@ -1,4 +1,4 @@
-PTF_BMV2_CMD = sudo ./ptf_runner.py --device bmv2 --port-map port_map.veth.json --ptf-dir fabric.ptf
+PTF_BMV2_CMD = sudo ./ptf_runner.py --device bmv2 --port-map port_map.veth.json --ptf-dir fabric.ptf --cpu-port 255
 BASE_P4C_OUT_PATH = ${ONOS_ROOT}/pipelines/fabric/src/main/resources/p4c-out
 FABRIC_OUT = ${BASE_P4C_OUT_PATH}/fabric/bmv2/default
 FABRIC_SPGW_OUT = ${BASE_P4C_OUT_PATH}/fabric-spgw/bmv2/default

--- a/tests/ptf/README.md
+++ b/tests/ptf/README.md
@@ -12,6 +12,15 @@ in the Python path.
 pre-compiled artifacts (no need to build ONOS, simply clone the repo)
 - Set `ONOS_ROOT` env variable to the location where you cloned the ONOS repo
 
+### ONOS+P4 Developer VM
+
+Alternatively, you can download this VM with all the necessary dependencies already installed:
+
+[Instructions to download and use the ONOS+P4 Developer VM](https://wiki.onosproject.org/x/FYnV#P4RuntimesupportinONOS-ONOS+P4DeveloperVM)
+
+The link provides also instructions to use Vagrant to build the VM locally.
+
+
 ## Before running the tests
 
 ### Fabric profiles
@@ -73,6 +82,9 @@ of the test machine.
 cd <path to bmv2 repo>/tools
 sudo ./veth_setup.sh
 ```
+
+If using the ONOS-P4 Dev VM, the `veth_setup.sh` script will be located
+under `/home/sdn`.
 
 2. Run the PTF tests using a convenient `make` command:
 

--- a/tests/ptf/base_test.py
+++ b/tests/ptf/base_test.py
@@ -195,6 +195,10 @@ class P4RuntimeTest(BaseTest):
         if grpc_addr is None:
             grpc_addr = 'localhost:50051'
 
+        self.cpu_port = int(testutils.test_param_get("cpu_port"))
+        if self.cpu_port is None:
+            self.fail("CPU port is not set")
+
         pltfm = testutils.test_param_get("pltfm")
         if pltfm is not None and pltfm == 'hw' and getattr(self, "_skip_on_hw", False):
             raise SkipTest("Skipping test in HW")

--- a/tests/ptf/fabric.ptf/test.py
+++ b/tests/ptf/fabric.ptf/test.py
@@ -55,6 +55,7 @@ HOST2_IPV4 = "10.0.2.1"
 ETH_TYPE_ARP = 0x0806
 ETH_TYPE_IPV4 = 0x0800
 
+
 def make_gtp(msg_len, teid, flags=0x30, msg_type=0xff):
     """Convenience function since GTP header has no scapy support"""
     return struct.pack(">BBHL", flags, msg_type, msg_len, teid)

--- a/tests/ptf/fabric.ptf/test.py
+++ b/tests/ptf/fabric.ptf/test.py
@@ -132,7 +132,7 @@ class FabricTest(P4RuntimeTest):
             "filtering.fwd_classifier",
             [self.Exact("standard_metadata.ingress_port", ingress_port_),
              self.Exact("hdr.ethernet.dst_addr", eth_dstAddr_),
-             self.Exact("fabric_metadata.original_ether_type", ethertype_)],
+             self.Exact("hdr.vlan_tag.ether_type", ethertype_)],
             "filtering.set_forwarding_type", [("fwd_type", fwd_type_)])
 
     def add_bridging_entry(self, vlan_id, eth_dstAddr, eth_dstAddr_mask,
@@ -164,7 +164,7 @@ class FabricTest(P4RuntimeTest):
         action_name = "clone_to_cpu" if clone else "punt_to_cpu"
         self.send_request_add_entry_to_action(
             "forwarding.acl",
-            [self.Ternary("fabric_metadata.original_ether_type", eth_type_, eth_type_mask)],
+            [self.Ternary("hdr.vlan_tag.ether_type", eth_type_, eth_type_mask)],
             "forwarding." + action_name, [],
             DEFAULT_PRIORITY)
 

--- a/tests/ptf/ptf_runner.py
+++ b/tests/ptf/ptf_runner.py
@@ -116,7 +116,7 @@ def update_config(p4info_path, bmv2_json_path, tofino_bin_path,
     return True
 
 
-def run_test(p4info_path, grpc_addr, ptfdir, port_map_path, platform=None, extra_args=()):
+def run_test(p4info_path, grpc_addr, cpu_port, ptfdir, port_map_path, platform=None, extra_args=()):
     """
     Runs PTF tests included in provided directory.
     Device must be running and configfured with appropriate P4 program.
@@ -151,6 +151,7 @@ def run_test(p4info_path, grpc_addr, ptfdir, port_map_path, platform=None, extra
     cmd.extend(ifaces)
     test_params = 'p4info=\'{}\''.format(p4info_path)
     test_params += ';grpcaddr=\'{}\''.format(grpc_addr)
+    test_params += ';cpu_port=\'{}\''.format(cpu_port)
     if platform is not None:
         test_params += ';pltfm=\'{}\''.format(platform)
     cmd.append('--test-params={}'.format(test_params))
@@ -205,6 +206,9 @@ def main():
     parser.add_argument('--device-id',
                         help='Device id for device under test',
                         type=int, default=0)
+    parser.add_argument('--cpu-port',
+                        help='CPU port ID of device under test',
+                        type=int, required=True)
     parser.add_argument('--ptf-dir',
                         help='Directory containing PTF tests',
                         type=str, required=True)
@@ -258,7 +262,7 @@ def main():
         bmv2_sw = Bmv2Switch(device_id=args.device_id,
                              port_map_path=args.port_map,
                              grpc_port=grpc_port,
-                             cpu_port=255,
+                             cpu_port=args.cpu_port,
                              loglevel='debug')
         bmv2_sw.start()
 
@@ -281,6 +285,7 @@ def main():
         if not args.skip_test:
             success = run_test(p4info_path=args.p4info,
                                grpc_addr=args.grpc_addr,
+                               cpu_port=args.cpu_port,
                                ptfdir=args.ptf_dir,
                                port_map_path=args.port_map,
                                platform=args.platform,


### PR DESCRIPTION
ARP requests need to be broadcasted to all ports of the same VLAN group,
but also cloned to the CPU for Trellis to learn about new hosts.

Requires this fabric.p4 change:
https://gerrit.onosproject.org/#/c/19137/