### PR TITLE
Add packet-in test for untagged packets coming from unconfigured ports

### DIFF
--- a/tests/ptf/fabric.ptf/test.py
+++ b/tests/ptf/fabric.ptf/test.py
@@ -320,6 +320,18 @@ class FabricTaggedPacketInTest(PacketInTest):
         self.runPacketInTest(pkt, ETH_TYPE_IPV4, tagged=True, vlan_id=10)
 
 
+@group("packetio")
+class FabricDefaultVlanPacketInTest(FabricTest):
+    @autocleanup
+    def runTest(self):
+        pkt = testutils.simple_eth_packet(pktlen=MIN_PKT_LEN)
+        self.add_forwarding_acl_cpu_entry(eth_type=pkt[Ether].type)
+        for port in [self.port1, self.port2]:
+            testutils.send_packet(self, port, str(pkt))
+            self.verify_packet_in(pkt, port)
+        testutils.verify_no_other_packets(self)
+
+
 @group("spgw")
 class SpgwDownlinkTest(SpgwSimpleTest):
     @autocleanup


### PR DESCRIPTION
For example, LLDP packets used by ONOS for link discovery.

Based on:
https://gerrit.onosproject.org/#/c/19524/