### PR TITLE
Various improvements to INT test cases

### DIFF
--- a/tests/ptf/Makefile
+++ b/tests/ptf/Makefile
@@ -26,7 +26,7 @@ endif
 
 fabric-int:
 ifndef TEST
-	$(eval TEST = all ^spgw)
+	$(eval TEST = all ^spgw ^int-full)
 endif
 	${PTF_BMV2_CMD} \
 		--p4info ${FABRIC_INT_OUT}/p4info.txt \

--- a/tests/ptf/base_test.py
+++ b/tests/ptf/base_test.py
@@ -566,10 +566,10 @@ class P4RuntimeTest(BaseTest):
         table_entry = update.entity.table_entry
         table_entry.table_id = self.get_table_id(t_name)
         table_entry.priority = priority
-        if mk is not None:
-            self.set_match_key(table_entry, t_name, mk)
-        else:
+        if mk is None or len(mk) == 0:
             table_entry.is_default_action = True
+        else:
+            self.set_match_key(table_entry, t_name, mk)
         self.set_action_entry(table_entry, a_name, params)
 
     def send_request_add_entry_to_action(self, t_name, mk, a_name, params, priority=0):

--- a/tests/ptf/fabric.ptf/test.py
+++ b/tests/ptf/fabric.ptf/test.py
@@ -460,14 +460,14 @@ class FabricIntSourceTest(IntTest):
         print ""
         for vlan_conf, tagged in vlan_confs.items():
             for pkt_type in ["udp", "tcp"]:
-                    for instructions in instr_sets:
-                        print "Testing VLAN=%s, pkt=%s, instructions=%s..." \
-                              % (vlan_conf, pkt_type, ",".join(
-                            [INT_INS_TO_NAME[i] for i in instructions]))
-                        pkt = getattr(testutils, "simple_%s_packet" % pkt_type)()
-                        self.doRunTest(pkt=pkt, instructions=instructions,
-                                       with_transit=False, ignore_csum=True,
-                                       tagged1=tagged[0], tagged2=tagged[1])
+                for instructions in instr_sets:
+                    print "Testing VLAN=%s, pkt=%s, instructions=%s..." \
+                          % (vlan_conf, pkt_type, ",".join(
+                        [INT_INS_TO_NAME[i] for i in instructions]))
+                    pkt = getattr(testutils, "simple_%s_packet" % pkt_type)()
+                    self.doRunTest(pkt=pkt, instructions=instructions,
+                                   with_transit=False, ignore_csum=True,
+                                   tagged1=tagged[0], tagged2=tagged[1])
 
 
 @group("int")

--- a/tests/ptf/fabric.ptf/test.py
+++ b/tests/ptf/fabric.ptf/test.py
@@ -15,6 +15,7 @@
 #
 
 import unittest
+from itertools import combinations
 
 from ptf.testutils import group
 from scapy.contrib.mpls import MPLS
@@ -459,14 +460,39 @@ class FabricIntSourceTest(IntTest):
         print ""
         for vlan_conf, tagged in vlan_confs.items():
             for pkt_type in ["udp", "tcp"]:
-                for transit in [True, False]:
                     for instructions in instr_sets:
-                        print "Testing VLAN=%s, pkt=%s, transit=%s, instructions=%s..." \
-                              % (vlan_conf, pkt_type, transit, ",".join([INT_INS_TO_NAME[i] for i in instructions]))
+                        print "Testing VLAN=%s, pkt=%s, instructions=%s..." \
+                              % (vlan_conf, pkt_type, ",".join(
+                            [INT_INS_TO_NAME[i] for i in instructions]))
                         pkt = getattr(testutils, "simple_%s_packet" % pkt_type)()
                         self.doRunTest(pkt=pkt, instructions=instructions,
-                                       with_transit=transit, ignore_csum=True,
+                                       with_transit=False, ignore_csum=True,
                                        tagged1=tagged[0], tagged2=tagged[1])
+
+
+@group("int")
+class FabricIntSourceAndTransitTest(IntTest):
+    @autocleanup
+    def doRunTest(self, **kwargs):
+        self.runIntSourceTest(**kwargs)
+
+    def runTest(self):
+        instr_sets = [
+            [INT_SWITCH_ID, INT_IG_EG_PORT],
+            [INT_SWITCH_ID, INT_IG_EG_PORT, INT_IG_TSTAMP, INT_EG_TSTAMP,
+             INT_QUEUE_OCCUPANCY]
+        ]
+        print ""
+        for vlan_conf, tagged in vlan_confs.items():
+            for pkt_type in ["udp", "tcp"]:
+                for instructions in instr_sets:
+                    print "Testing VLAN=%s, pkt=%s, instructions=%s..." \
+                          % (vlan_conf, pkt_type, ",".join(
+                        [INT_INS_TO_NAME[i] for i in instructions]))
+                    pkt = getattr(testutils, "simple_%s_packet" % pkt_type)()
+                    self.doRunTest(pkt=pkt, instructions=instructions,
+                                   with_transit=True, ignore_csum=True,
+                                   tagged1=tagged[0], tagged2=tagged[1])
 
 
 @group("int")
@@ -482,13 +508,45 @@ class FabricIntTransitTest(IntTest):
         ]
         print ""
         for vlan_conf, tagged in vlan_confs.items():
-            for pkt_type in ["tcp", "udp"]:
+            for pkt_type in ["udp", "tcp"]:
                 for prev_hops in [0, 3]:
                     for instructions in instr_sets:
                         print "Testing VLAN=%s, pkt=%s, prev_hops=%s, instructions=%s..." \
                               % (vlan_conf, pkt_type, prev_hops,
                                  ",".join([INT_INS_TO_NAME[i] for i in instructions]))
                         pkt = getattr(testutils, "simple_%s_packet" % pkt_type)()
+                        hop_metadata, _ = self.get_int_metadata(
+                            instructions, 0xCAFEBABE, 0xDEAD, 0xBEEF)
+                        int_pkt = self.get_int_pkt(
+                            pkt=pkt, instructions=instructions, max_hop=50,
+                            transit_hops=prev_hops, hop_metadata=hop_metadata)
+                        self.doRunTest(
+                            pkt=int_pkt, tagged1=tagged[0], tagged2=tagged[1],
+                            ignore_csum=1)
+
+
+@group("int")
+@group("int-full")
+class FabricIntTransitFullTest(IntTest):
+    @autocleanup
+    def doRunTest(self, **kwargs):
+        self.runIntTransitTest(**kwargs)
+
+    def runTest(self):
+        instr_sets = []
+        for num_instr in range(1, len(INT_ALL_INSTRUCTIONS) + 1):
+            instr_sets.extend(combinations(INT_ALL_INSTRUCTIONS, num_instr))
+        print ""
+        for vlan_conf, tagged in vlan_confs.items():
+            for pkt_type in ["udp"]:
+                for prev_hops in [0, 3]:
+                    for instructions in instr_sets:
+                        print "Testing VLAN=%s, pkt=%s, prev_hops=%s, instructions=%s..." \
+                              % (vlan_conf, pkt_type, prev_hops,
+                                 ",".join([INT_INS_TO_NAME[i] for i in
+                                           instructions]))
+                        pkt = getattr(testutils,
+                                      "simple_%s_packet" % pkt_type)()
                         hop_metadata, _ = self.get_int_metadata(
                             instructions, 0xCAFEBABE, 0xDEAD, 0xBEEF)
                         int_pkt = self.get_int_pkt(

--- a/tests/ptf/fabric.ptf/test.py
+++ b/tests/ptf/fabric.ptf/test.py
@@ -460,12 +460,12 @@ class FabricIntSourceTest(IntTest):
         print ""
         for vlan_conf, tagged in vlan_confs.items():
             for pkt_type in ["udp", "tcp"]:
-                for instructions in instr_sets:
+                for instrs in instr_sets:
                     print "Testing VLAN=%s, pkt=%s, instructions=%s..." \
-                          % (vlan_conf, pkt_type, ",".join(
-                        [INT_INS_TO_NAME[i] for i in instructions]))
+                          % (vlan_conf, pkt_type,
+                             ",".join([INT_INS_TO_NAME[i] for i in instrs]))
                     pkt = getattr(testutils, "simple_%s_packet" % pkt_type)()
-                    self.doRunTest(pkt=pkt, instructions=instructions,
+                    self.doRunTest(pkt=pkt, instructions=instrs,
                                    with_transit=False, ignore_csum=True,
                                    tagged1=tagged[0], tagged2=tagged[1])
 
@@ -485,12 +485,12 @@ class FabricIntSourceAndTransitTest(IntTest):
         print ""
         for vlan_conf, tagged in vlan_confs.items():
             for pkt_type in ["udp", "tcp"]:
-                for instructions in instr_sets:
+                for instrs in instr_sets:
                     print "Testing VLAN=%s, pkt=%s, instructions=%s..." \
-                          % (vlan_conf, pkt_type, ",".join(
-                        [INT_INS_TO_NAME[i] for i in instructions]))
+                          % (vlan_conf, pkt_type,
+                             ",".join([INT_INS_TO_NAME[i] for i in instrs]))
                     pkt = getattr(testutils, "simple_%s_packet" % pkt_type)()
-                    self.doRunTest(pkt=pkt, instructions=instructions,
+                    self.doRunTest(pkt=pkt, instructions=instrs,
                                    with_transit=True, ignore_csum=True,
                                    tagged1=tagged[0], tagged2=tagged[1])
 

--- a/tests/ptf/fabric_test.py
+++ b/tests/ptf/fabric_test.py
@@ -602,18 +602,7 @@ class IntTest(IPv4UnicastTest):
         self.send_request_add_entry_to_action(
             "tb_int_insert",
             [],
-            "int_transit", [("switch_id", stringify(switch_id, 4))])
-
-        for inst_mask in ("0003", "0407"):
-            req = self.get_new_write_request()
-            for i in xrange(16):
-                base = "int_set_header_%s_i" % inst_mask
-                mf = self.Exact("hdr.int_header.instruction_mask_" + inst_mask,
-                                stringify(i, 1))
-                action = base + str(i)
-                self.push_update_add_entry_to_action(
-                    req, "tb_int_inst_" + inst_mask, [mf], action, [])
-            self.write_request(req)
+            "init_metadata", [("switch_id", stringify(switch_id, 4))])
 
     def setup_source_port(self, source_port):
         source_port_ = stringify(source_port, 2)


### PR DESCRIPTION
- Fixed bug where P4Runtime entry with empty match key was created
without default action flag.
- Split INT source test case to validate only source functionality or
source+transit.
- Removed programming of instruction mask tables, now pre-populated
with static entries.
- Introduce new transit test case to asses all possible instruction
combinations (not executed by default)