### PR TITLE
Modifications to allow Stratum to use a few files from this repo

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,31 @@
+#
+# Copyright 2019 Open Networking Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+licenses(["notice"])  # Apache v2
+
+exports_files(["LICENSE"])
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "fabric_p4test_stratum_p4_test_files",
+    srcs = ["tests/ptf/ptf_runner.py",
+            "tests/ptf/base_test.py",
+            "tests/ptf/bmv2.py",
+            "tests/ptf/port_map.veth.json"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "com_github_opennetworkinglab_fabric_p4test")

--- a/tests/ptf/bmv2.py
+++ b/tests/ptf/bmv2.py
@@ -35,17 +35,20 @@ def get_stratum_root():
     else:
         return '/home/sdn/stratum'
 
+
 def get_stratum_ld_path():
     if 'LD_LIBRARY_PATH' in os.environ:
         return 'LD_LIBRARY_PATH=' + os.environ['LD_LIBRARY_PATH']
     else:
         return 'LD_LIBRARY_PATH=/home/sdn/bmv2_install/lib'
 
+
 STRATUM_ROOT = get_stratum_root()
 STRATUM_BINARY = STRATUM_ROOT + '/bazel-bin/stratum/hal/bin/bmv2/stratum_bmv2'
 STRATUM_CONFIG_DIR = '/tmp/stratum-bmv2'
 STRATUM_LD_PATH = get_stratum_ld_path()
 INITIAL_PIPELINE = STRATUM_ROOT + '/stratum/hal/bin/bmv2/dummy.json'
+
 
 def check_bmv2_target(target):
     try:

--- a/tests/ptf/bmv2.py
+++ b/tests/ptf/bmv2.py
@@ -35,13 +35,17 @@ def get_stratum_root():
     else:
         return '/home/sdn/stratum'
 
+def get_stratum_ld_path():
+    if 'LD_LIBRARY_PATH' in os.environ:
+        return 'LD_LIBRARY_PATH=' + os.environ['LD_LIBRARY_PATH']
+    else:
+        return 'LD_LIBRARY_PATH=/home/sdn/bmv2_install/lib'
 
 STRATUM_ROOT = get_stratum_root()
 STRATUM_BINARY = STRATUM_ROOT + '/bazel-bin/stratum/hal/bin/bmv2/stratum_bmv2'
 STRATUM_CONFIG_DIR = '/tmp/stratum-bmv2'
-STRATUM_LD_PATH = 'LD_LIBRARY_PATH=/home/sdn/bmv2_install/lib'
+STRATUM_LD_PATH = get_stratum_ld_path()
 INITIAL_PIPELINE = STRATUM_ROOT + '/stratum/hal/bin/bmv2/dummy.json'
-
 
 def check_bmv2_target(target):
     try:
@@ -92,7 +96,7 @@ class Bmv2Switch:
             '--persistent_config_dir=' + STRATUM_CONFIG_DIR,
             '--initial_pipeline=' + INITIAL_PIPELINE,
             '--cpu_port=%s' % self.cpu_port,
-            '--url=0.0.0.0:%s' % self.grpc_port,
+            '--external-hercules-urls=0.0.0.0:%s' % self.grpc_port,
         ]
         for port, intf in port_map.items():
             args.append('%d@%s' % (port, intf))


### PR DESCRIPTION
This Pull Request is in reference to Stratum's `PR #100: Update loopback.p4 to P4_16` that includes a simple PTF test.

During that PR review, it was suggested that files `ptf_runner.py` and `base_test.py` that were originally copied to the Stratum repo be taken from this repo instead.

The suggested changes are described below.  These also include some modifications that were required to fix some issues found while testing with Stratum.

- Addition of files `WORKSPACE` and `BUILD` to allow managing dependencies with Bazel.

- Modifications to `bmv2.py` to set `STRATUM_LD_PATH` with the value of `LD_LIBRARY_PATH` when it is defined.  When `LD_LIBRARY_PATH` is not defined, the path that was originally specified is used.

- Modified Stratum parameter `--url` to `--external-hercules-urls`.

- Updated code in `ptf_runner.py` to wait for the arbitration message response before calling `SetForwardingPipelineConfig`.  The original code was not waiting for that response and it sometimes created a PERMISSION_DENIED error.  Tracing in the Stratum code showed that this was caused by command `SetForwardingPipelineConfig` pre-empting the arbitration message.

