### PR TITLE
Addition of --skip-launch parameter to ptf_runner.py.

### DIFF
--- a/tests/ptf/ptf_runner.py
+++ b/tests/ptf/ptf_runner.py
@@ -286,6 +286,9 @@ def main():
     parser.add_argument('--skip-test',
                         help='Skip test execution (useful to perform only pipeline configuration)',
                         action="store_true", default=False)
+    parser.add_argument('--skip-launch',
+                        help='Skip switch launch (requires that switch be started manually beforehand)',
+                        action="store_true", default=False)
     args, unknown_args = parser.parse_known_args()
 
     if not check_ptf():
@@ -322,21 +325,22 @@ def main():
     grpc_port = args.grpc_addr.split(':')[1]
 
     bmv2_sw = None
-    if device == 'bmv2':
-        bmv2_sw = Bmv2Switch(device_id=args.device_id,
-                             port_map_path=args.port_map,
-                             grpc_port=grpc_port,
-                             cpu_port=args.cpu_port,
-                             loglevel='debug')
-        bmv2_sw.start()
-    elif device == 'stratum-bmv2':
-        bmv2_sw = Bmv2Switch(device_id=args.device_id,
-                             port_map_path=args.port_map,
-                             grpc_port=grpc_port,
-                             cpu_port=args.cpu_port,
-                             loglevel='debug',
-                             is_stratum=True)
-        bmv2_sw.start()
+    if args.skip_launch == False:
+        if device == 'bmv2':
+            bmv2_sw = Bmv2Switch(device_id=args.device_id,
+                                 port_map_path=args.port_map,
+                                 grpc_port=grpc_port,
+                                 cpu_port=args.cpu_port,
+                                 loglevel='debug')
+            bmv2_sw.start()
+        elif device == 'stratum-bmv2':
+            bmv2_sw = Bmv2Switch(device_id=args.device_id,
+                                 port_map_path=args.port_map,
+                                 grpc_port=grpc_port,
+                                 cpu_port=args.cpu_port,
+                                 loglevel='debug',
+                                 is_stratum=True)
+            bmv2_sw.start()
 
     try:
 

--- a/tests/ptf/ptf_runner.py
+++ b/tests/ptf/ptf_runner.py
@@ -286,8 +286,9 @@ def main():
     parser.add_argument('--skip-test',
                         help='Skip test execution (useful to perform only pipeline configuration)',
                         action="store_true", default=False)
-    parser.add_argument('--skip-launch',
-                        help='Skip switch launch (requires that switch be started manually beforehand)',
+    parser.add_argument('--skip-bmv2-start',
+                        help='Skip switch start (requires that the switch be started manually \
+                        beforehand, only applies to bmv2 and bmv2-stratum targets)',
                         action="store_true", default=False)
     args, unknown_args = parser.parse_known_args()
 
@@ -325,7 +326,7 @@ def main():
     grpc_port = args.grpc_addr.split(':')[1]
 
     bmv2_sw = None
-    if args.skip_launch is False:
+    if args.skip_bmv2_start is False:
         if device == 'bmv2':
             bmv2_sw = Bmv2Switch(device_id=args.device_id,
                                  port_map_path=args.port_map,

--- a/tests/ptf/ptf_runner.py
+++ b/tests/ptf/ptf_runner.py
@@ -325,7 +325,7 @@ def main():
     grpc_port = args.grpc_addr.split(':')[1]
 
     bmv2_sw = None
-    if args.skip_launch == False:
+    if args.skip_launch is False:
         if device == 'bmv2':
             bmv2_sw = Bmv2Switch(device_id=args.device_id,
                                  port_map_path=args.port_map,


### PR DESCRIPTION

This PR proposes the addition of parameter `--skip-launch` to ptf_runner.py to allow running tests using a previously-started instance of either bmv2 or stratum-bmv2.

One use of this would be to view the traces that are output to the terminal by Stratum and/or BMV2 during execution (configuration and packet processing).

Also, combining `--skip-launch` and `--skip-test` allows `ptf_runner.py` to mimic Stratum's `update_config.py`, which is useful when only a pipeline needs to be pushed using P4Runtime.

