### PR TITLE
Renamed --external-hercules-urls for --external-stratum-url when starting Stratum (#61).

### DIFF
--- a/tests/ptf/bmv2.py
+++ b/tests/ptf/bmv2.py
@@ -99,7 +99,7 @@ class Bmv2Switch:
             '--persistent_config_dir=/dev/null',
             '--initial_pipeline=' + stratumRoot + INITIAL_PIPELINE,
             '--cpu_port=%s' % self.cpu_port,
-            '--external-hercules-urls=0.0.0.0:%s' % self.grpc_port,
+            '--external-stratum-urls=0.0.0.0:%s' % self.grpc_port,
         ]
         for port, intf in port_map.items():
             args.append('%d@%s' % (port, intf))


### PR DESCRIPTION
Stratum parameter `--external-hercules-urls` was renamed `--external-stratum-urls` recently.  Needed to update `get_stratum_cmd` to be in-line with this change.