### PR TITLE
Fix to BNG counters and check if counter type is supported

### DIFF
--- a/tests/ptf/base_test.py
+++ b/tests/ptf/base_test.py
@@ -646,7 +646,12 @@ class P4RuntimeTest(BaseTest):
         self.push_update_add_entry_to_group(req, t_name, mk, grp_id)
         return req, self.write_request(req, store=(mk is not None))
 
-    def read_counter(self, c_name, c_index):
+    def read_counter(self, c_name, c_index, typ):
+        # Check counter type with P4Info
+        counter = self.get_counter(c_name)
+        counter_type_unit = p4info_pb2.CounterSpec.Unit.items()[counter.spec.unit][0]
+        if counter_type_unit != "BOTH" and counter_type_unit != typ:
+            raise Exception("Counter " + c_name + " is of type " + counter_type_unit + ", but requested: " + typ)
         req = self.get_new_read_request()
         entity = req.entities.add()
         counter_entry = entity.counter_entry


### PR DESCRIPTION
Some counters of the BNG pipeline have beed updated to support just packets or bytes counters, tests are updated to support this change.
Also, since BMv2 always allocate bytes and packets counter even if only one of the 2 unit is selected, this patch add a check on the counter type on the P4Info when reading a counter.