### PR TITLE
Updated docker image to fix tcpdump warnings

### DIFF
--- a/run/bmv2/run
+++ b/run/bmv2/run
@@ -9,7 +9,7 @@ MN_STRATUM_IMG="opennetworking/mn-stratum:latest@sha256:1bba2e2c06460c73b0133ae2
 
 # Tester image
 # Contains PTF and tvutils libraries, as well as P4RT, gNMI, and TV Python bindings
-TESTER_DOCKER_IMG=stratumproject/testvectors:ptf@sha256:43a4cb251fd86270dbca1f77608669e039779d7b9ae31b7c18b7480f282bfb28
+TESTER_DOCKER_IMG=stratumproject/testvectors:ptf@sha256:6eff3274b13b8ec5f218c7275f79e33177c5af6cc5e5ed793d064ac2f6ec5698
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 ROOT_DIR=${DIR}/../..

--- a/run/tm/run
+++ b/run/tm/run
@@ -20,7 +20,7 @@ FP4TEST_ROOT="${DIR}"/../..
 
 # Tester image
 # Contains PTF and tvutils libraries, as well as P4RT, gNMI, and TV Python bindings
-TESTER_DOCKER_IMG=stratumproject/testvectors:ptf@sha256:43a4cb251fd86270dbca1f77608669e039779d7b9ae31b7c18b7480f282bfb28
+TESTER_DOCKER_IMG=stratumproject/testvectors:ptf@sha256:6eff3274b13b8ec5f218c7275f79e33177c5af6cc5e5ed793d064ac2f6ec5698
 SDE_VERSION=${SDE_VERSION:-9.0.0}
 # Use image sha to pin a specific stratum_bmv2 build and have reproducible runs.
 # We could instrument CI to test on both a stable version and the latest one.

--- a/run/tv/run
+++ b/run/tv/run
@@ -4,7 +4,7 @@ set -e
 
 # Tester image
 # Contains PTF and tvutils libraries, as well as P4RT, gNMI, and TV Python bindings
-TESTER_DOCKER_IMG=stratumproject/testvectors:ptf@sha256:43a4cb251fd86270dbca1f77608669e039779d7b9ae31b7c18b7480f282bfb28
+TESTER_DOCKER_IMG=stratumproject/testvectors:ptf@sha256:6eff3274b13b8ec5f218c7275f79e33177c5af6cc5e5ed793d064ac2f6ec5698
 SDE_VERSION=${SDE_VERSION:-9.0.0}
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"


### PR DESCRIPTION
Changed the docker image sha. This fixes tcpdum, /etc/services and /etc/protocols warnings that we saw with older image. Accidentally created a branch in original repo instead of my fork.