### PR TITLE
Bridged packets should retain the same TTL

### DIFF
--- a/tests/ptf/fabric_test.py
+++ b/tests/ptf/fabric_test.py
@@ -610,10 +610,9 @@ class BridgingTest(FabricTest):
         self.add_next_output(10, self.port1)
         self.add_next_output(20, self.port2)
 
-        exp_pkt = pkt_decrement_ttl(pkt.copy())
+        exp_pkt = pkt.copy()
         pkt2 = pkt_mac_swap(pkt.copy())
-        exp_pkt2 = pkt_decrement_ttl(pkt2.copy())
-
+        exp_pkt2 = pkt2.copy()
         if tagged1:
             pkt = pkt_add_vlan(pkt, vlan_vid=vlan_id)
             exp_pkt2 = pkt_add_vlan(exp_pkt2, vlan_vid=vlan_id)
@@ -642,7 +641,7 @@ class DoubleVlanXConnectTest(FabricTest):
 
         pkt = pkt_add_vlan(pkt, vlan_vid=vlan_id_inner)
         pkt = pkt_add_vlan(pkt, vlan_vid=vlan_id_outer)
-        exp_pkt = pkt_decrement_ttl(pkt.copy())
+        exp_pkt = pkt.copy()
 
         self.send_packet(self.port1, str(pkt))
         self.verify_packet(exp_pkt, self.port2)


### PR DESCRIPTION
Corresponding P4 code change is here: https://gerrit.onosproject.org/c/onos/+/23952